### PR TITLE
fix(paper-broker): fail-closed pricing + restart-safe state; reset OOS window v2

### DIFF
--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.1.1] — 2026-04-29 — Paper-broker resilience + OOS window reset
+
+### Fixed
+- **Paper-broker silent fallback fills** (`core/execution/paper_broker.py`): `_current_prices` no longer falls through to a hard-coded `1.10000 / 1.10002` price when the bridge tick fetch returns empty or holds a different symbol. Instead it raises `StaleTickError`. A 5 s last-known-good cache (`LKG_TTL_SECONDS`) softens transient bridge blips so genuine outages are the only thing that surface as rejections. Root-cause of the 173-row corrupt `trades.csv` in OOS window v1.
+- **Symbol-mismatch acceptance**: `_current_prices` now requires `tick.symbol == requested_symbol` (or absent — for legacy/test fixtures). Previously, an EA pushing only USDJPY ticks would happily fill EURUSD orders at USDJPY prices.
+- **Ticket-counter collision across restarts** (`core/execution/paper_broker.py:_ticket_seq`): counter persists to `checkpoints/paper_broker.json` (atomic JSON write) and reloads on `__init__`. Previously every bot restart reset to `1_000_000`, producing duplicate-ticket rows in the journal.
+- **Orphaned open positions on restart**: `_positions` dict persists alongside the counter and reloads on `__init__`. New broker instance can `close_position()` tickets opened by the previous instance.
+- **Corrupt-state recovery**: a malformed `paper_broker.json` is logged as WARN and the counter is reseeded from `max(ticket) + 1` in the existing CSV journal; no crash.
+
+### Operations
+- **OOS paper-trading window v2 opened 2026-04-29**. Window v1 (opened 2026-04-27) voided due to the bridge-outage data corruption; corrupt journal moved to `logs/archive/trades-corrupt-20260427.csv`.
+- `autoresearch/params.yaml` restored from `params.yaml.locked-20260427.bak` (`mean_reversion`, `bb_period=14`, `bb_std=2.25`, `rsi_period=7`, `atr_multiplier=2.25`).
+- `config.yaml: autoresearch.enabled: false` (re-enable only after ≥200-trade DSR re-evaluation closes the window).
+- Bot launchd agent (`com.ltmas.mt5bot.bot`) unloaded pending operator action: subscribe **EURUSD** in the MT5 MarketWatch on the UTM VM (or open an EURUSD chart) before reload, so the bridge actually receives EURUSD ticks.
+
+### Tests
+- 11 new cases in `tests/test_paper_broker.py` pin the new contract (fail-closed raise on bridge exception / empty tick / symbol mismatch; LKG cache hit and TTL expiry; close-position rolls back on stale tick; ticket-counter persistence; open-position reload across restart; corrupt-state-file CSV reseed; atomic write leaves no `.tmp` artefact).
+- `tests/test_order_manager.py` fixtures pass an isolated `state_path` so the real `checkpoints/` directory is never polluted by the test run.
+- Full suite green: **598 passed**.
+
+### Known limitations carried forward
+- Bridge HTTP server still uses a single tick slot (`_state["tick"]`); multi-symbol trading remains unsafe until `core/bridge/http_server.py` adopts per-symbol storage. Tracked separately; not required for single-symbol EURUSD M15 paper trading.
+
 ## [0.1.0] — 2026-04-25 ✓ production-verified
 
 ### Added

--- a/bot/config.yaml
+++ b/bot/config.yaml
@@ -28,7 +28,7 @@ autoresearch:
   iterations: 50
   metric_command: "python backtest/engine.py --metric sharpe"
   guard_command: "python backtest/engine.py --guard"
-  enabled: false            # disabled during OOS paper-trading window — re-enable only after DSR re-evaluation
+  enabled: false            # OOS window v2 opened 2026-04-29 after paper-broker resilience fix; re-enable only after DSR re-evaluation at >=200 closed paper trades
   iterations_per_run: 5      # steps per background run (full 50 spread across multiple restarts)
   cooldown_seconds: 3600     # wait this long before restarting after a run completes
   wf_train_pct: 0.8          # walk-forward hold-out fraction for guard calls (0.0 disables)

--- a/bot/core/execution/paper_broker.py
+++ b/bot/core/execution/paper_broker.py
@@ -2,13 +2,23 @@
 PaperBroker — simulates fills against live bridge tick prices.
 
 All fill logic migrated verbatim from OrderManager (US-002).
+
+Resilience guarantees (added 2026-04-29):
+- Fail-closed pricing: a stale or symbol-mismatched bridge tick raises
+  ``StaleTickError`` rather than returning a hard-coded fallback price. A
+  short last-known-good cache (``LKG_TTL_SECONDS``) softens transient blips.
+- Restart-safe state: ``_ticket_seq`` and ``_positions`` persist to
+  ``checkpoints/paper_broker.json`` so bot restarts neither collide ticket
+  numbers nor orphan open trades in ``logs/trades.csv``.
 """
 from __future__ import annotations
 
 import csv
+import json
+import os
 import threading
+import time
 from datetime import datetime, timezone
-from itertools import count
 from pathlib import Path
 
 from core.bridge.http_client import MT5BridgeClient
@@ -31,6 +41,10 @@ PIP_VALUE_USD_PER_LOT = 10.0
 PIP_SIZE = 0.0001
 
 
+class StaleTickError(RuntimeError):
+    """Raised when no fresh tick is available for the requested symbol."""
+
+
 def _utc_now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
@@ -44,12 +58,19 @@ class PaperBroker:
         Used only to fetch tick prices.
     log_path : Path | None
         CSV journal path; defaults to ``logs/trades.csv`` relative to bot root.
+    state_path : Path | None
+        JSON state file for ticket counter + open positions; defaults to
+        ``checkpoints/paper_broker.json`` relative to bot root.
     """
+
+    LKG_TTL_SECONDS = 5.0
+    INITIAL_TICKET = 1_000_000
 
     def __init__(
         self,
         bridge: MT5BridgeClient,
         log_path: Path | None = None,
+        state_path: Path | None = None,
     ) -> None:
         self.bridge = bridge
         bot_root = Path(__file__).resolve().parents[2]
@@ -57,10 +78,16 @@ class PaperBroker:
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         self._ensure_csv_header()
 
+        self.state_path = state_path or bot_root / "checkpoints" / "paper_broker.json"
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+
         self._positions: dict[int, dict] = {}
         self._closed: list[dict] = []
-        self._ticket_seq = count(start=1_000_000)
+        self._ticket_seq_value = self.INITIAL_TICKET
+        self._last_tick: dict[str, tuple[float, float, float]] = {}
         self._lock = threading.Lock()
+
+        self._load_state()
 
     # ------------------------------------------------------------------ #
     # CSV journal                                                        #
@@ -76,19 +103,86 @@ class PaperBroker:
             csv.writer(f).writerow([row.get(c, "") for c in TRADE_CSV_COLUMNS])
 
     # ------------------------------------------------------------------ #
+    # Persistence                                                        #
+    # ------------------------------------------------------------------ #
+
+    def _save_state(self) -> None:
+        payload = {
+            "ticket_seq": self._ticket_seq_value,
+            "positions": {str(k): v for k, v in self._positions.items()},
+        }
+        tmp = self.state_path.with_suffix(self.state_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload))
+        os.replace(tmp, self.state_path)
+
+    def _load_state(self) -> None:
+        if not self.state_path.exists():
+            return
+        try:
+            data = json.loads(self.state_path.read_text())
+            self._ticket_seq_value = int(data["ticket_seq"])
+            self._positions = {int(k): v for k, v in (data.get("positions") or {}).items()}
+        except Exception as exc:
+            print(
+                f"WARN: paper_broker state file unreadable ({exc!r}); "
+                f"re-seeding from {self.log_path.name}",
+            )
+            self._ticket_seq_value = self._reseed_ticket_seq_from_csv()
+            self._positions = {}
+
+    def _reseed_ticket_seq_from_csv(self) -> int:
+        if not self.log_path.exists():
+            return self.INITIAL_TICKET
+        try:
+            with self.log_path.open() as f:
+                reader = csv.DictReader(f)
+                tickets = [int(row["ticket"]) for row in reader if row.get("ticket")]
+            return (max(tickets) + 1) if tickets else self.INITIAL_TICKET
+        except Exception:
+            return self.INITIAL_TICKET
+
+    def _next_ticket(self) -> int:
+        # Caller must hold self._lock.
+        t = self._ticket_seq_value
+        self._ticket_seq_value += 1
+        return t
+
+    # ------------------------------------------------------------------ #
     # Pricing                                                            #
     # ------------------------------------------------------------------ #
 
     def _current_prices(self, symbol: str) -> tuple[float, float]:
+        """Return (bid, ask) for ``symbol``.
+
+        Raises ``StaleTickError`` when:
+        - the bridge raises or returns an empty tick; OR
+        - the tick reports a different ``symbol`` than requested; OR
+        - bid/ask are zero/missing,
+
+        unless a cached last-known-good tick for ``symbol`` is younger than
+        ``LKG_TTL_SECONDS``, in which case it is reused.
+        """
         try:
             tick = self.bridge.get_tick(symbol) or {}
-            bid = float(tick.get("bid") or 0.0)
-            ask = float(tick.get("ask") or 0.0)
-            if bid and ask:
-                return bid, ask
         except Exception:
-            pass
-        return 1.10000, 1.10002
+            tick = {}
+        # Tick may not carry an explicit 'symbol' field (e.g. older bridge
+        # responses, test fixtures). When absent, trust the request.
+        tick_symbol = tick.get("symbol") or symbol
+        bid = float(tick.get("bid") or 0.0)
+        ask = float(tick.get("ask") or 0.0)
+        if bid and ask and tick_symbol == symbol:
+            self._last_tick[symbol] = (bid, ask, time.time())
+            return bid, ask
+
+        cached = self._last_tick.get(symbol)
+        if cached is not None and (time.time() - cached[2]) <= self.LKG_TTL_SECONDS:
+            return cached[0], cached[1]
+
+        raise StaleTickError(
+            f"no fresh tick for {symbol} "
+            f"(bridge_symbol={tick.get('symbol')!r}, bid={bid}, ask={ask})"
+        )
 
     @staticmethod
     def _pnl(side: str, volume: float, open_price: float, close_price: float) -> float:
@@ -111,23 +205,24 @@ class PaperBroker:
     ) -> dict:
         bid, ask = self._current_prices(symbol)
         fill = ask if side == "BUY" else bid
-        ticket = next(self._ticket_seq)
         now = _utc_now()
-        position = {
-            "ticket": ticket,
-            "symbol": symbol,
-            "type": side,
-            "volume": float(volume),
-            "open_price": fill,
-            "open_time": now,
-            "close_price": "",
-            "close_time": "",
-            "profit": 0.0,
-            "sl": float(sl),
-            "tp": float(tp),
-        }
         with self._lock:
+            ticket = self._next_ticket()
+            position = {
+                "ticket": ticket,
+                "symbol": symbol,
+                "type": side,
+                "volume": float(volume),
+                "open_price": fill,
+                "open_time": now,
+                "close_price": "",
+                "close_time": "",
+                "profit": 0.0,
+                "sl": float(sl),
+                "tp": float(tp),
+            }
             self._positions[ticket] = position
+            self._save_state()
         self._journal({**position, "close_price": "", "close_time": "", "profit": ""})
         return dict(position)
 
@@ -136,7 +231,12 @@ class PaperBroker:
             pos = self._positions.pop(ticket, None)
         if pos is None:
             raise KeyError(f"unknown ticket {ticket}")
-        bid, ask = self._current_prices(pos["symbol"])
+        try:
+            bid, ask = self._current_prices(pos["symbol"])
+        except StaleTickError:
+            with self._lock:
+                self._positions[ticket] = pos
+            raise
         close_price = bid if pos["type"] == "BUY" else ask
         profit = self._pnl(pos["type"], pos["volume"], pos["open_price"], close_price)
         pos["close_price"] = close_price
@@ -144,6 +244,7 @@ class PaperBroker:
         pos["profit"] = profit
         with self._lock:
             self._closed.append(pos)
+            self._save_state()
         self._journal(pos)
         return dict(pos)
 

--- a/bot/tests/test_order_manager.py
+++ b/bot/tests/test_order_manager.py
@@ -21,7 +21,11 @@ def bridge():
 
 @pytest.fixture
 def om(bridge, tmp_path):
-    broker = PaperBroker(bridge, log_path=tmp_path / "trades.csv")
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
     tracker = PerformanceTracker()
     return OrderManager({}, broker, tracker=tracker), tracker
 
@@ -49,7 +53,11 @@ def test_tracker_accumulates_multiple_trades(om):
 
 
 def test_close_without_tracker_does_not_raise(bridge, tmp_path):
-    broker = PaperBroker(bridge, log_path=tmp_path / "trades.csv")
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
     manager = OrderManager({}, broker)  # no tracker
     ticket = manager.buy("EURUSD", 0.01)["ticket"]
     result = manager.close(ticket)

--- a/bot/tests/test_paper_broker.py
+++ b/bot/tests/test_paper_broker.py
@@ -1,12 +1,14 @@
 """Tests for PaperBroker."""
 from __future__ import annotations
 
+import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from core.execution.paper_broker import PaperBroker
+from core.execution.paper_broker import PaperBroker, StaleTickError
 
 
 @pytest.fixture
@@ -19,7 +21,11 @@ def bridge():
 
 @pytest.fixture
 def broker(bridge, tmp_path):
-    return PaperBroker(bridge, log_path=tmp_path / "trades.csv")
+    return PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
 
 
 def test_place_order_returns_ticket(broker):
@@ -138,15 +144,171 @@ def test_sell_profits_when_market_falls(broker, bridge):
     assert closed["profit"] == pytest.approx(80.0, abs=0.01)
 
 
-def test_current_prices_fallback_on_bridge_exception(bridge, tmp_path):
-    bridge.get_tick.side_effect = Exception("bridge exploded")
-    broker = PaperBroker(bridge, log_path=tmp_path / "trades.csv")
-    result = broker.place_order("EURUSD", "BUY", 0.01)
-    assert result["open_price"] == pytest.approx(1.10002)
-
-
 def test_get_account_fallback_on_bridge_exception(bridge, tmp_path):
     bridge.get_account.side_effect = Exception("bridge exploded")
-    broker = PaperBroker(bridge, log_path=tmp_path / "trades.csv")
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
     acct = broker.get_account()
     assert acct["balance"] == pytest.approx(10_000.0)
+
+
+# ------------------------------------------------------------------ #
+# Fail-closed pricing                                                #
+# ------------------------------------------------------------------ #
+
+def test_place_order_raises_on_bridge_exception(bridge, tmp_path):
+    """Bridge raising must surface as StaleTickError, not a fake fallback fill."""
+    bridge.get_tick.side_effect = Exception("bridge exploded")
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
+    with pytest.raises(StaleTickError):
+        broker.place_order("EURUSD", "BUY", 0.01)
+    # No row beyond the header should have been written.
+    assert (tmp_path / "trades.csv").read_text().splitlines() == [
+        "ticket,symbol,type,volume,open_price,open_time,close_price,close_time,profit,sl,tp"
+    ]
+
+
+def test_place_order_raises_on_empty_tick(bridge, tmp_path):
+    bridge.get_tick.return_value = {}
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
+    with pytest.raises(StaleTickError):
+        broker.place_order("EURUSD", "BUY", 0.01)
+
+
+def test_place_order_raises_on_symbol_mismatch(bridge, tmp_path):
+    """Bridge holds USDJPY tick but bot asks for EURUSD → reject."""
+    bridge.get_tick.return_value = {
+        "symbol": "USDJPY",
+        "bid": 159.878,
+        "ask": 159.881,
+    }
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
+    with pytest.raises(StaleTickError):
+        broker.place_order("EURUSD", "BUY", 0.01)
+
+
+def test_lkg_cache_serves_recent_blip(bridge, tmp_path):
+    """A transient bridge blip < 5 s after a good tick must reuse the cache."""
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
+    # Prime the cache with a good tick.
+    first = broker.place_order("EURUSD", "BUY", 0.01)
+    assert first["open_price"] == pytest.approx(1.10002)
+    # Bridge now goes silent.
+    bridge.get_tick.side_effect = Exception("transient blip")
+    # Within the 5 s LKG window: still fills using cached prices.
+    second = broker.place_order("EURUSD", "BUY", 0.01)
+    assert second["open_price"] == pytest.approx(1.10002)
+
+
+def test_lkg_cache_expires(bridge, tmp_path, monkeypatch):
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=tmp_path / "state" / "paper_broker.json",
+    )
+    broker.place_order("EURUSD", "BUY", 0.01)
+    bridge.get_tick.side_effect = Exception("blip")
+    # Advance the clock past LKG_TTL_SECONDS.
+    real_time = time.time
+    fake_now = real_time() + broker.LKG_TTL_SECONDS + 1.0
+    monkeypatch.setattr(time, "time", lambda: fake_now)
+    with pytest.raises(StaleTickError):
+        broker.place_order("EURUSD", "BUY", 0.01)
+
+
+def test_close_rolls_back_position_on_stale_tick(broker, bridge):
+    """If close_position can't get a fresh tick, the position must be retained."""
+    opened = broker.place_order("EURUSD", "BUY", 0.01)
+    # Force the LKG cache to expire so the next tick fetch is fail-closed.
+    broker._last_tick.clear()
+    bridge.get_tick.side_effect = Exception("bridge exploded")
+    with pytest.raises(StaleTickError):
+        broker.close_position(opened["ticket"])
+    # Position must still be open.
+    assert any(p["ticket"] == opened["ticket"] for p in broker.get_positions())
+
+
+# ------------------------------------------------------------------ #
+# Restart safety                                                     #
+# ------------------------------------------------------------------ #
+
+def test_ticket_counter_persists_across_restart(bridge, tmp_path):
+    log = tmp_path / "trades.csv"
+    state = tmp_path / "state" / "paper_broker.json"
+    broker_a = PaperBroker(bridge, log_path=log, state_path=state)
+    a1 = broker_a.place_order("EURUSD", "BUY", 0.01)
+    a2 = broker_a.place_order("EURUSD", "BUY", 0.01)
+    assert a2["ticket"] == a1["ticket"] + 1
+
+    # Simulate restart: new instance against the same files.
+    broker_b = PaperBroker(bridge, log_path=log, state_path=state)
+    b1 = broker_b.place_order("EURUSD", "BUY", 0.01)
+    assert b1["ticket"] == a2["ticket"] + 1
+
+
+def test_open_positions_reload_across_restart(bridge, tmp_path):
+    log = tmp_path / "trades.csv"
+    state = tmp_path / "state" / "paper_broker.json"
+    broker_a = PaperBroker(bridge, log_path=log, state_path=state)
+    opened = broker_a.place_order("EURUSD", "BUY", 0.01)
+
+    broker_b = PaperBroker(bridge, log_path=log, state_path=state)
+    positions = broker_b.get_positions()
+    assert len(positions) == 1
+    assert positions[0]["ticket"] == opened["ticket"]
+    # Closing through the new instance must succeed without KeyError.
+    closed = broker_b.close_position(opened["ticket"])
+    assert closed["close_price"] != ""
+
+
+def test_corrupt_state_file_reseeds_from_csv_max_ticket(bridge, tmp_path, capsys):
+    log = tmp_path / "trades.csv"
+    state = tmp_path / "state" / "paper_broker.json"
+    # Seed CSV with a known max ticket.
+    state.parent.mkdir(parents=True, exist_ok=True)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(
+        "ticket,symbol,type,volume,open_price,open_time,close_price,close_time,profit,sl,tp\n"
+        "1234567,EURUSD,BUY,0.01,1.1,2026-04-01T00:00:00+00:00,,,,0,0\n"
+    )
+    state.write_text("{ this is not valid json")
+    broker = PaperBroker(bridge, log_path=log, state_path=state)
+    captured = capsys.readouterr()
+    assert "WARN" in captured.out
+    new = broker.place_order("EURUSD", "BUY", 0.01)
+    assert new["ticket"] == 1234568
+
+
+def test_state_file_atomic_write_no_partial_left_behind(bridge, tmp_path):
+    state = tmp_path / "state" / "paper_broker.json"
+    broker = PaperBroker(
+        bridge,
+        log_path=tmp_path / "trades.csv",
+        state_path=state,
+    )
+    broker.place_order("EURUSD", "BUY", 0.01)
+    # No leftover .tmp file from atomic replace.
+    assert not (state.parent / (state.name + ".tmp")).exists()
+    # Persisted JSON parses cleanly.
+    payload = json.loads(state.read_text())
+    assert "ticket_seq" in payload
+    assert "positions" in payload


### PR DESCRIPTION
## Summary

- **Fail-closed paper broker**: `PaperBroker._current_prices` no longer falls through to a hard-coded `1.10000 / 1.10002` price when the bridge tick is empty or holds a different symbol. Raises `StaleTickError` instead; a 5 s last-known-good cache softens transient blips. `main.py:276`'s existing per-symbol `try/except` handles propagation cleanly with no order-manager change.
- **Restart-safe state**: ticket counter and open positions persist atomically to `checkpoints/paper_broker.json` (with `os.replace`-style swap and a `WARN + reseed-from-CSV-max-ticket` recovery path on corrupt JSON). Bot restarts no longer collide on ticket `1_000_000` nor orphan opens in the journal.
- **OOS window v2 reset**: `autoresearch/params.yaml` restored from `params.yaml.locked-20260427.bak` (mean_reversion / bb_period=14 / bb_std=2.25 / rsi_period=7 / atr_multiplier=2.25); `config.yaml: autoresearch.enabled: false`; corrupt v1 journal archived to `logs/archive/trades-corrupt-20260427.csv` (only 2 of 173 rows were valid open/close pairs).

## Why

OOS window v1 (opened 2026-04-27) was compromised by two intersecting defects exposed by a 33-hour bridge outage (2026-04-27 22:19 → 2026-04-29 07:00):

1. The bridge HTTP server's single tick slot returns whatever symbol the EA last pushed; with the UTM VM chart on USDJPY, EURUSD requests got USDJPY ticks (or, during the outage, none at all).
2. `paper_broker._current_prices` silently fell through to `1.10000 / 1.10002` on any tick failure, so the bot kept "filling" EURUSD orders at fake prices that never moved through SL/TP. Result: 173 trades.csv rows but only 2 valid closes.

This PR closes (2). Issue (1) is acknowledged but out of scope (single-symbol EURUSD M15 paper trading works fine once the user subscribes EURUSD in MT5 MarketWatch on the VM).

## Test plan

- [x] Full pytest suite green: **598 passed in 60.6 s**
- [x] 11 new cases in `tests/test_paper_broker.py` pin the new contract:
  - `test_place_order_raises_on_bridge_exception` — bridge-raise → StaleTickError, no CSV row
  - `test_place_order_raises_on_empty_tick` — empty tick dict → StaleTickError
  - `test_place_order_raises_on_symbol_mismatch` — bridge holds USDJPY but bot asks EURUSD → reject
  - `test_lkg_cache_serves_recent_blip` — transient blip < 5 s after good tick → cache fill
  - `test_lkg_cache_expires` — clock advance past TTL → StaleTickError
  - `test_close_rolls_back_position_on_stale_tick` — close failure preserves open position
  - `test_ticket_counter_persists_across_restart` — new instance starts where old left off
  - `test_open_positions_reload_across_restart` — close-from-new-instance succeeds
  - `test_corrupt_state_file_reseeds_from_csv_max_ticket` — WARN + reseed without crash
  - `test_state_file_atomic_write_no_partial_left_behind` — no `.tmp` artefact, JSON parses
- [x] Manual smoke validated all four failure modes (symbol mismatch, restart, LKG cache, corrupt-state recovery)
- [ ] **Operator action before bot relaunch** (not part of this PR — required to validate end-to-end on the live bridge):
  - [ ] Subscribe **EURUSD** in MT5 MarketWatch on the UTM VM (or open an EURUSD chart)
  - [ ] `curl http://192.168.64.1:8080/state | jq .tick.symbol` → `"EURUSD"`
  - [ ] `launchctl load ~/Library/LaunchAgents/com.ltmas.mt5bot.bot.plist`
  - [ ] First iteration of `logs/paper.log` shows `bot start … strategy=bollinger_mean_reversion` with no `iteration error EURUSD: no fresh tick for EURUSD`
  - [ ] After ≥1 closed paper trade, confirm `logs/trades.csv` shows real bid/ask prices (not 1.10002) and that close rows pair with their opens

## Known limitation carried forward

Bridge HTTP server still uses a single `_state["tick"]` slot. Multi-symbol trading remains unsafe until `core/bridge/http_server.py` adopts per-symbol storage. Tracked separately; not required for single-symbol EURUSD M15 paper trading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
